### PR TITLE
support overriding environment variables by passing -o env=k=v

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ docker-volume-juicefs
 plugin
 bin
 .vagrant
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,25 @@
 FROM golang:1.17 as builder
 
 ARG GOPROXY
+ENV GOPROXY=${GOPROXY:-"https://proxy.golang.org,direct"}
 ARG JUICEFS_CE_VERSION
+ENV JUICEFS_CE_VERSION=${JUICEFS_CE_VERSION:-"main"}
 
 WORKDIR /docker-volume-juicefs
 COPY . .
-ENV GOPROXY=${GOPROXY:-"https://proxy.golang.org,direct"}
-RUN apt-get update && apt-get install -y curl musl-tools tar gzip upx-ucl \
-    && CC=/usr/bin/musl-gcc go build -o bin/docker-volume-juicefs \
-       --ldflags '-linkmode external -extldflags "-static"' .
+RUN apt-get update && apt-get install -y curl musl-tools tar gzip upx-ucl && \
+    CC=/usr/bin/musl-gcc go build -o bin/docker-volume-juicefs --ldflags '-linkmode external -extldflags "-static"' .
 
 WORKDIR /workspace
-ENV JUICEFS_CE_VERSION=${JUICEFS_CE_VERSION:-"main"}
-RUN curl -fsSL -o juicefs-${JUICEFS_CE_VERSION}.tar.gz \
-       https://github.com/juicedata/juicefs/archive/${JUICEFS_CE_VERSION}.tar.gz \
-    && mkdir juicefs \
-    && tar -xf juicefs-${JUICEFS_CE_VERSION}.tar.gz --strip-components=1 -C juicefs \
-    && cd juicefs && STATIC=1 make && upx juicefs
-
-RUN curl -fsSL -o /juicefs https://s.juicefs.com/static/juicefs \
-    && chmod +x /juicefs
+RUN curl -fsSL -o juicefs-ce.tar.gz https://github.com/juicedata/juicefs/releases/download/v${JUICEFS_CE_VERSION}/juicefs-${JUICEFS_CE_VERSION}-linux-amd64.tar.gz && \
+    tar -zxf juicefs-ce.tar.gz -C /tmp && \
+    curl -fsSL -o /juicefs https://s.juicefs.com/static/juicefs && \
+    chmod +x /juicefs
 
 FROM python:2.7-alpine
 RUN mkdir -p /run/docker/plugins /jfs/state /jfs/volumes
 COPY --from=builder /docker-volume-juicefs/bin/docker-volume-juicefs /
-COPY --from=builder /workspace/juicefs/juicefs /bin/
+COPY --from=builder /tmp/juicefs /bin/
 COPY --from=builder /juicefs /usr/bin/
 RUN /usr/bin/juicefs version && /bin/juicefs --version
 CMD ["docker-volume-juicefs"]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PLUGIN_NAME = juicedata/juicefs
 PLUGIN_TAG ?= latest
-JUICEFS_CE_VERSION ?= main
+JUICEFS_CE_VERSION ?= 1.0.4
 
 all: clean rootfs create
 

--- a/README.md
+++ b/README.md
@@ -7,15 +7,15 @@ Modified from https://github.com/vieux/docker-volume-sshfs
 ## Usage
 
 ``` shell
-$ docker plugin install juicedata/juicefs
+docker plugin install juicedata/juicefs
 
 # JuiceFS open sourced version
-$ docker volume create -d juicedata/juicefs:latest -o name=$JFS_VOL -o metaurl=$JFS_META_URL -o access-key=$JFS_ACCESSKEY -o secret-key=JFS_SECRETKEY jfsvolume
-$ docker run -it -v jfsvolume:/opt busybox ls /opt
+docker volume create -d juicedata/juicefs:latest -o name=$JFS_VOL -o metaurl=$JFS_META_URL -o access-key=$JFS_ACCESSKEY -o secret-key=JFS_SECRETKEY jfsvolume
+docker run -it -v jfsvolume:/opt busybox ls /opt
 
 # JuiceFS hosted version
-$ docker volume create -d juicedata/juicefs:latest -o name=$JFS_VOL -o token=$JFS_TOKEN -o accesskey=$JFS_ACCESSKEY -o secretkey=$JFS_SECRETKEY jfsvolume
-$ docker run -it -v jfsvolume:/opt busybox ls /opt
+docker volume create -d juicedata/juicefs:latest -o name=$JFS_VOL -o token=$JFS_TOKEN -o accesskey=$JFS_ACCESSKEY -o secretkey=$JFS_SECRETKEY jfsvolume
+docker run -it -v jfsvolume:/opt busybox ls /opt
 ```
 
 ## Development

--- a/main.go
+++ b/main.go
@@ -75,14 +75,16 @@ func (d *jfsDriver) saveState() {
 }
 
 func ceMount(v *jfsVolume) error {
-	// copy option map
 	options := map[string]string{}
+	format := exec.Command(ceCliPath, "format", "--no-update")
 	for k, v := range v.Options {
+		if k == "env" {
+			format.Env = append(os.Environ(), strings.Split(v, ",")...)
+			logrus.Debug("modified env: %s", format.Env)
+			continue
+		}
 		options[k] = v
 	}
-
-	// possible options for `juicefs format`
-	format := exec.Command(ceCliPath, "format", "--no-update")
 	formatOptions := []string{
 		"block-size",
 		"compress",
@@ -157,14 +159,16 @@ func ceMount(v *jfsVolume) error {
 }
 
 func eeMount(v *jfsVolume) error {
-	// copy option map
+	auth := exec.Command(cliPath, "auth", v.Name)
 	options := map[string]string{}
 	for k, v := range v.Options {
+		if k == "env" {
+			auth.Env = append(os.Environ(), strings.Split(v, ",")...)
+			logrus.Debug("modified env: %s", auth.Env)
+			continue
+		}
 		options[k] = v
 	}
-
-	// possible options for `juicefs auth`
-	auth := exec.Command(cliPath, "auth", v.Name)
 	authOptions := []string{
 		"token",
 		"accesskey",


### PR DESCRIPTION
add environment variables by using:

```shell
$ docker volume create -d juicedata/juicefs:latest -o name=xx -o token=xx -o accesskey=xx -o secretkey=xx -o env=FOO=bar,SPAM=egg
```

closes https://github.com/juicedata/docker-volume-juicefs/issues/30
might close https://github.com/juicedata/docker-volume-juicefs/issues/28