### PR TITLE
Fix #62: ceMount retry loop panics with 'exec: already started'

### DIFF
--- a/main.go
+++ b/main.go
@@ -155,7 +155,6 @@ func ceMount(v *jfsVolume) error {
 		logrus.Debug(string(output))
 	}()
 
-	touch := exec.Command("touch", v.Mountpoint+"/.juicefs")
 	var fileinfo os.FileInfo
 	var err error
 	for attempt := 0; attempt < 10; attempt++ {
@@ -165,6 +164,7 @@ func ceMount(v *jfsVolume) error {
 				return logError("Not a syscall.Stat_t")
 			}
 			if stat.Ino == 1 {
+				touch := exec.Command("touch", v.Mountpoint+"/.juicefs")
 				if err = touch.Run(); err == nil {
 					return nil
 				}

--- a/main.go
+++ b/main.go
@@ -265,7 +265,6 @@ func eeMount(v *jfsVolume) error {
 		return logError(err.Error())
 	}
 
-	touch := exec.Command("touch", v.Mountpoint+"/.juicefs")
 	var fileinfo os.FileInfo
 	var err error
 	for attempt := 0; attempt < 3; attempt++ {
@@ -275,6 +274,7 @@ func eeMount(v *jfsVolume) error {
 				return logError("Not a syscall.Stat_t")
 			}
 			if stat.Ino == 1 {
+				touch := exec.Command("touch", v.Mountpoint+"/.juicefs")
 				if err = touch.Run(); err == nil {
 					return nil
 				}


### PR DESCRIPTION
## Summary

Fixes #62

## Problem

In `ceMount()`, the `touch` command is initialized **outside** the retry loop, but `(*exec.Cmd).Run()` can only be called once per instance. If the first attempt fails (e.g. permission denied), every subsequent retry panics with `exec: already started`, eventually causing the plugin to crash with an `EOF` error returned to Docker.

## Fix

Move `exec.Command` creation inside the loop so a fresh process is started on each attempt.

## Testing

Validated that the plugin builds and the mount retry loop works correctly after the fix.