### PR TITLE
Fix #64: Add mount health check using Ino==1 detection

### DIFF
--- a/main.go
+++ b/main.go
@@ -479,8 +479,10 @@ func (d *jfsDriver) Unmount(r *volume.UnmountRequest) error {
 		return logError("failed to umount %s: %s", r.Name, err)
 	}
 
-	v.stopHealthCheck()
 	v.connections--
+	if v.connections == 0 {
+		v.stopHealthCheck()
+	}
 	return nil
 }
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -25,11 +26,14 @@ const (
 )
 
 type jfsVolume struct {
-	Name        string
-	Options     map[string]string
-	Source      string
-	Mountpoint  string
-	connections int
+	Name              string
+	Options           map[string]string
+	Source            string
+	Mountpoint        string
+	connections       int
+	healthCheckCtx    context.Context
+	healthCheckCancel context.CancelFunc
+	mu                sync.Mutex
 }
 
 type jfsDriver struct {
@@ -72,6 +76,50 @@ func (d *jfsDriver) saveState() {
 
 	if err := ioutil.WriteFile(d.statePath, data, 0600); err != nil {
 		logrus.WithField("saveState", d.statePath).Error(err)
+	}
+}
+
+func isJuicefsMounted(mountpoint string) bool {
+	fi, err := os.Lstat(mountpoint)
+	if err != nil {
+		return false
+	}
+	stat, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return false
+	}
+	return stat.Ino == 1
+}
+
+func (v *jfsVolume) startHealthCheck() {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if v.healthCheckCancel != nil {
+		v.healthCheckCancel()
+	}
+	v.healthCheckCtx, v.healthCheckCancel = context.WithCancel(context.Background())
+	go func() {
+		ticker := time.NewTicker(30 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				if !isJuicefsMounted(v.Mountpoint) {
+					logrus.Errorf("JuiceFS mount at %s is no longer active", v.Mountpoint)
+				}
+			case <-v.healthCheckCtx.Done():
+				return
+			}
+		}
+	}()
+}
+
+func (v *jfsVolume) stopHealthCheck() {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if v.healthCheckCancel != nil {
+		v.healthCheckCancel()
+		v.healthCheckCancel = nil
 	}
 }
 
@@ -155,7 +203,6 @@ func ceMount(v *jfsVolume) error {
 		logrus.Debug(string(output))
 	}()
 
-	touch := exec.Command("touch", v.Mountpoint+"/.juicefs")
 	var fileinfo os.FileInfo
 	var err error
 	for attempt := 0; attempt < 10; attempt++ {
@@ -165,7 +212,9 @@ func ceMount(v *jfsVolume) error {
 				return logError("Not a syscall.Stat_t")
 			}
 			if stat.Ino == 1 {
+				touch := exec.Command("touch", v.Mountpoint+"/.juicefs")
 				if err = touch.Run(); err == nil {
+					v.startHealthCheck()
 					return nil
 				}
 			}
@@ -265,7 +314,6 @@ func eeMount(v *jfsVolume) error {
 		return logError(err.Error())
 	}
 
-	touch := exec.Command("touch", v.Mountpoint+"/.juicefs")
 	var fileinfo os.FileInfo
 	var err error
 	for attempt := 0; attempt < 3; attempt++ {
@@ -275,7 +323,9 @@ func eeMount(v *jfsVolume) error {
 				return logError("Not a syscall.Stat_t")
 			}
 			if stat.Ino == 1 {
+				touch := exec.Command("touch", v.Mountpoint+"/.juicefs")
 				if err = touch.Run(); err == nil {
+					v.startHealthCheck()
 					return nil
 				}
 			}
@@ -397,6 +447,9 @@ func (d *jfsDriver) Path(r *volume.PathRequest) (*volume.PathResponse, error) {
 func (d *jfsDriver) Mount(r *volume.MountRequest) (*volume.MountResponse, error) {
 	logrus.WithField("method", "mount").Debugf("%#v", r)
 
+	d.Lock()
+	defer d.Unlock()
+
 	v, ok := d.volumes[r.Name]
 	if !ok {
 		return &volume.MountResponse{}, logError("volume %s not found", r.Name)
@@ -414,6 +467,9 @@ func (d *jfsDriver) Mount(r *volume.MountRequest) (*volume.MountResponse, error)
 func (d *jfsDriver) Unmount(r *volume.UnmountRequest) error {
 	logrus.WithField("method", "umount").Debugf("%#v", r)
 
+	d.Lock()
+	defer d.Unlock()
+
 	v, ok := d.volumes[r.Name]
 	if !ok {
 		return logError("volume %s not found", r.Name)
@@ -423,6 +479,7 @@ func (d *jfsDriver) Unmount(r *volume.UnmountRequest) error {
 		return logError("failed to umount %s: %s", r.Name, err)
 	}
 
+	v.stopHealthCheck()
 	v.connections--
 	return nil
 }


### PR DESCRIPTION
## Summary

Fixes #64 — FUSE mount death causes silent fallback to local disk, filling up host storage.

## Changes

- Add a periodic health check (every 30s) that detects when a JuiceFS mount is no longer active by checking `stat.Ino == 1` on the mountpoint, consistent with the existing mount verification in `ceMount`/`eeMount`
- When mount death is detected, the driver logs an `ERROR` so the issue is **no longer silent**
- The health check runs in a goroutine with `context.Context`-based cancellation on unmount
- Add `sync.Mutex` to `jfsVolume` for thread-safe health check lifecycle management
- Add locking to `Mount()` and `Unmount()` driver methods

## Addressing review feedback

Per @zxh326's review on the previous PR (#66):

> I would also avoid using "is this path any FUSE mount?" as the health signal here. The existing mount verification already checks stat.Ino == 1 on the mountpoint, which is a better signal for this driver because it verifies that the path still looks like the JuiceFS mount root.

✅ This PR now uses `Ino == 1` instead of parsing `/proc/self/mountinfo` for FUSE mount detection.

> It only logs when /proc/self/mountinfo no longer shows the mountpoint as a FUSE mount, but the driver still returns the same mountpoint from Mount()/Path(). That means Docker can still continue writing to the local directory after the JuiceFS mount is gone.

The health check currently logs when the mount dies, making the issue **visible** rather than silent. A future enhancement could attempt automatic remount, but that introduces complexity (re-acquiring credentials, race conditions with concurrent Docker operations) that should be discussed separately.

## Also includes

- Fix ceMount retry bug: `exec.Command` moved inside the loop since `Cmd.Run()` can only be called once per instance (addresses #62)