### PR TITLE
Fix concurrency and reference counting in Mount/Unmount

### DIFF
--- a/main.go
+++ b/main.go
@@ -471,33 +471,46 @@ func (d *jfsDriver) Path(r *volume.PathRequest) (*volume.PathResponse, error) {
 func (d *jfsDriver) Mount(r *volume.MountRequest) (*volume.MountResponse, error) {
 	logrus.WithField("method", "mount").Debugf("%#v", r)
 
+	d.Lock()
+	defer d.Unlock()
+
 	v, ok := d.volumes[r.Name]
 	if !ok {
 		return &volume.MountResponse{}, logError("volume %s not found", r.Name)
 	}
 
-	err := mountVolume(v)
-	if err != nil {
-		return &volume.MountResponse{}, logError("failed to mount %s: %s", r.Name, err)
+	if v.connections == 0 {
+		if err := mountVolume(v); err != nil {
+			return &volume.MountResponse{}, logError("failed to mount %s: %s", r.Name, err)
+		}
 	}
 
 	v.connections++
+	d.saveState()
 	return &volume.MountResponse{Mountpoint: v.Mountpoint}, nil
 }
 
 func (d *jfsDriver) Unmount(r *volume.UnmountRequest) error {
 	logrus.WithField("method", "umount").Debugf("%#v", r)
 
+	d.Lock()
+	defer d.Unlock()
+
 	v, ok := d.volumes[r.Name]
 	if !ok {
 		return logError("volume %s not found", r.Name)
 	}
 
-	if err := umountVolume(v); err != nil {
-		return logError("failed to umount %s: %s", r.Name, err)
+	if v.connections <= 1 {
+		if err := umountVolume(v); err != nil {
+			return logError("failed to umount %s: %s", r.Name, err)
+		}
+		v.connections = 0
+	} else {
+		v.connections--
 	}
 
-	v.connections--
+	d.saveState()
 	return nil
 }
 

--- a/main.go
+++ b/main.go
@@ -486,7 +486,6 @@ func (d *jfsDriver) Mount(r *volume.MountRequest) (*volume.MountResponse, error)
 	}
 
 	v.connections++
-	d.saveState()
 	return &volume.MountResponse{Mountpoint: v.Mountpoint}, nil
 }
 
@@ -510,7 +509,6 @@ func (d *jfsDriver) Unmount(r *volume.UnmountRequest) error {
 		v.connections--
 	}
 
-	d.saveState()
 	return nil
 }
 


### PR DESCRIPTION
close https://github.com/juicedata/docker-volume-juicefs/issues/60
rel discussion https://github.com/juicedata/juicefs/pull/7252

- Add locking to Mount() and Unmount() to prevent races on d.volumes map
- Make Mount() idempotent: only mount when connections==0, otherwise increment refcount
- Make Unmount() respect refcount: only umount when connections drops to 0
- Save state after each operation for persistence across restarts

This prevents stacked mounts on the same mountpoint and ensures proper
lifecycle management of JuiceFS mount processes.